### PR TITLE
fix: add generator strategy DOCSTOOLS-5561

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @diplodoc-platform/team

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,12 +32,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.21.1
           cache: 'npm'
 
       - name: Install latest npm (>= 11.5.1)
         run: |
-          [ "$(printf '%s\n' "11.5.1" "$(npm -v)" | sort -V | head -n1)" = "11.5.1" ] || npm install -g npm@latest
+          [ "$(printf '%s\n' "11.5.1" "$(npm -v)" | sort -V | head -n1)" = "11.5.1" ] || npm install -g npm@11.5.1
         shell: bash
 
       - name: Install dependencies

--- a/.github/workflows/package-lock.yml
+++ b/.github/workflows/package-lock.yml
@@ -27,13 +27,13 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.21.1
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
       - name: Install latest npm (>= 11.5.1)
         run: |
-          [ "$(printf '%s\n' "11.5.1" "$(npm -v)" | sort -V | head -n1)" = "11.5.1" ] || npm install -g npm@latest
+          [ "$(printf '%s\n' "11.5.1" "$(npm -v)" | sort -V | head -n1)" = "11.5.1" ] || npm install -g npm@11.5.1
         shell: bash
 
       - name: Regenerate package-lock.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,12 @@
 # To modify this workflow, edit it in diplodoc/devops/lint/scaffolding/.github/workflows/
 # and then run the scaffolding update process.
 
-name: Release to npm
+name: Release Package to npm
 
-# This workflow handles both stable and prerelease publishing to npm
+# This workflow handles stable releases, prereleases, and deprecation:
 # - Stable: triggered by release event or manual dispatch with 'stable' type
 # - Prerelease: triggered by manual dispatch with 'prerelease' type (only from non-protected branches)
+# - Deprecate: triggered by manual dispatch with 'deprecate' type (marks a version as deprecated)
 
 on:
   release:
@@ -22,6 +23,19 @@ on:
         options:
           - prerelease
           - stable
+          - deprecate
+      deprecate_version:
+        description: 'Version to deprecate (only for deprecate type)'
+        required: false
+        type: string
+      deprecate_message:
+        description: 'Deprecation message (only for deprecate type)'
+        required: false
+        type: string
+      deprecate_new_latest:
+        description: 'New latest version (required when deprecating current latest)'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -32,10 +46,12 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     # For prerelease - only from non-protected branches
+    # For deprecate - always allowed
     if: |
       github.event_name == 'release' ||
       (github.event_name == 'workflow_dispatch' && inputs.release_type == 'stable') ||
-      (github.event_name == 'workflow_dispatch' && inputs.release_type == 'prerelease' && github.ref_protected != true)
+      (github.event_name == 'workflow_dispatch' && inputs.release_type == 'prerelease' && github.ref_protected != true) ||
+      (github.event_name == 'workflow_dispatch' && inputs.release_type == 'deprecate')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -45,24 +61,31 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.21.1
           registry-url: 'https://registry.npmjs.org'
+
+      - uses: codex-team/action-nodejs-package-info@v1
+        id: package
 
       - name: Install latest npm (>= 11.5.1)
         run: |
-          [ "$(printf '%s\n' "11.5.1" "$(npm -v)" | sort -V | head -n1)" = "11.5.1" ] || npm install -g npm@latest
+          [ "$(printf '%s\n' "11.5.1" "$(npm -v)" | sort -V | head -n1)" = "11.5.1" ] || npm install -g npm@11.5.1
         shell: bash
 
       - name: Install dependencies
+        if: inputs.release_type != 'deprecate'
         run: npm ci
 
       - name: Run tests
+        if: inputs.release_type != 'deprecate'
         run: npm test
 
       - name: Run type check
+        if: inputs.release_type != 'deprecate'
         run: npm run typecheck
 
       - name: Build package
+        if: inputs.release_type != 'deprecate'
         run: npm run build
 
       # === STABLE RELEASE STEPS ===
@@ -100,3 +123,41 @@ jobs:
         run: npm publish --tag $(git branch --show-current) --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # === DEPRECATE STEPS ===
+      - name: Validate deprecate inputs
+        if: github.event_name == 'workflow_dispatch' && inputs.release_type == 'deprecate'
+        run: |
+          if [[ -z "${{ inputs.deprecate_version }}" ]]; then
+            echo "::error::deprecate_version is required for deprecate action"
+            exit 1
+          fi
+          if [[ -z "${{ inputs.deprecate_message }}" ]]; then
+            echo "::error::deprecate_message is required for deprecate action"
+            exit 1
+          fi
+
+      - name: Deprecate version
+        if: github.event_name == 'workflow_dispatch' && inputs.release_type == 'deprecate'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -e
+
+          PACKAGE="${{ steps.package.outputs.name }}"
+          LATEST="$(npm view $PACKAGE@latest version 2>/dev/null || echo '')"
+          VERSION="${{ inputs.deprecate_version }}"
+          MESSAGE="${{ inputs.deprecate_message }}"
+          TARGET="$PACKAGE@$VERSION"
+
+          if [[ "$LATEST" == "$VERSION" ]]; then
+            if [[ -z "${{ inputs.deprecate_new_latest }}" ]]; then
+              echo "::error::deprecate_new_latest is required when deprecating the current latest version ($LATEST)"
+              exit 1
+            fi
+            echo "::notice::Setting new latest tag to $PACKAGE@${{ inputs.deprecate_new_latest }}"
+            npm dist-tag add "$PACKAGE@${{ inputs.deprecate_new_latest }}" latest
+          fi
+
+          echo "::notice::Deprecating $TARGET. Reason: $MESSAGE"
+          npm deprecate "$TARGET" "$MESSAGE"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,12 +25,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 22.21.1
           cache: 'npm'
 
       - name: Install latest npm (>= 11.5.1)
         run: |
-          [ "$(printf '%s\n' "11.5.1" "$(npm -v)" | sort -V | head -n1)" = "11.5.1" ] || npm install -g npm@latest
+          [ "$(printf '%s\n' "11.5.1" "$(npm -v)" | sort -V | head -n1)" = "11.5.1" ] || npm install -g npm@11.5.1
         shell: bash
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [22]
+        node-version: [22.21.1]
 
     steps:
       - name: Checkout repository
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install latest npm (>= 11.5.1)
         run: |
-          [ "$(printf '%s\n' "11.5.1" "$(npm -v)" | sort -V | head -n1)" = "11.5.1" ] || npm install -g npm@latest
+          [ "$(printf '%s\n' "11.5.1" "$(npm -v)" | sort -V | head -n1)" = "11.5.1" ] || npm install -g npm@11.5.1
         shell: bash
 
       - name: Install dependencies

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -9,8 +9,42 @@ on:
   workflow_dispatch:
     inputs:
       package:
-        description: 'Package name to update'
-        required: true
+        description: 'Package name to update (single selection)'
+        required: false
+        type: choice
+        options:
+          # === packages ===
+          - '@diplodoc/client'
+          - '@diplodoc/components'
+          - '@diplodoc/directive'
+          - '@diplodoc/liquid'
+          - '@diplodoc/sentenizer'
+          - '@diplodoc/transform'
+          - '@diplodoc/translation'
+          - '@diplodoc/utils'
+          - '@diplodoc/yfmlint'
+          # === extensions ===
+          - '@diplodoc/algolia-extension'
+          - '@diplodoc/color-extension'
+          - '@diplodoc/cut-extension'
+          - '@diplodoc/file-extension'
+          - '@diplodoc/folding-headings-extension'
+          - '@diplodoc/html-extension'
+          - '@diplodoc/latex-extension'
+          - '@diplodoc/mermaid-extension'
+          - '@diplodoc/openapi-extension'
+          - '@diplodoc/page-constructor-extension'
+          - '@diplodoc/quote-link-extension'
+          - '@diplodoc/search-extension'
+          - '@diplodoc/tabs-extension'
+      update_as_dev:
+        description: 'Update as devDependency (only for single package selection)'
+        required: false
+        type: boolean
+        default: false
+      packages:
+        description: 'Package names to update (comma-separated, e.g., "@diplodoc/transform,dev:@diplodoc/client"). Use "dev:" prefix for devDependencies. If empty, uses single package selection above.'
+        required: false
         type: string
       version:
         description: 'Package version (use "latest" for latest version)'
@@ -35,20 +69,60 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.21.1
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
       - name: Install latest npm (>= 11.5.1)
         run: |
-          [ "$(printf '%s\n' "11.5.1" "$(npm -v)" | sort -V | head -n1)" = "11.5.1" ] || npm install -g npm@latest
+          [ "$(printf '%s\n' "11.5.1" "$(npm -v)" | sort -V | head -n1)" = "11.5.1" ] || npm install -g npm@11.5.1
         shell: bash
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Update package
-        run: npm install --no-workspaces ${{ inputs.package }}@${{ inputs.version }}
+      - name: Update packages
+        run: |
+          set -e
+
+          # Determine which packages to update
+          if [[ -n "${{ inputs.packages }}" ]]; then
+            # Use multi-selection field with dev: prefix support
+            PACKAGES_INPUT="${{ inputs.packages }}"
+            
+            # Parse comma-separated packages
+            IFS=',' read -ra PACKAGES <<< "$PACKAGES_INPUT"
+            
+            for PACKAGE_ENTRY in "${PACKAGES[@]}"; do
+              # Trim whitespace
+              PACKAGE_ENTRY=$(echo "$PACKAGE_ENTRY" | xargs)
+              
+              # Check for dev: prefix
+              if [[ "$PACKAGE_ENTRY" == dev:* ]]; then
+                PACKAGE="${PACKAGE_ENTRY#dev:}"
+                echo "::info::Updating $PACKAGE to ${{ inputs.version }} as devDependency"
+                npm install --no-workspaces --save-dev "$PACKAGE@${{ inputs.version }}"
+              else
+                PACKAGE="$PACKAGE_ENTRY"
+                echo "::info::Updating $PACKAGE to ${{ inputs.version }}"
+                npm install --no-workspaces "$PACKAGE@${{ inputs.version }}"
+              fi
+            done
+          elif [[ -n "${{ inputs.package }}" ]]; then
+            # Use single selection field
+            PACKAGE="${{ inputs.package }}"
+            
+            if [[ "${{ inputs.update_as_dev }}" == "true" ]]; then
+              echo "::info::Updating $PACKAGE to ${{ inputs.version }} as devDependency"
+              npm install --no-workspaces --save-dev "$PACKAGE@${{ inputs.version }}"
+            else
+              echo "::info::Updating $PACKAGE to ${{ inputs.version }}"
+              npm install --no-workspaces "$PACKAGE@${{ inputs.version }}"
+            fi
+          else
+            echo "::error::Either package or packages must be specified"
+            exit 1
+          fi
 
       - name: Regenerate package-lock.json for standalone mode
         run: npm install --no-workspaces --package-lock-only
@@ -65,20 +139,64 @@ jobs:
             exit 0
           fi
 
-          # Get actual installed version
-          VERSION=$(npm explore --no-workspaces ${{ inputs.package }} "node -pe 'require(\"./package.json\").version'" --shell sh)
+          # Determine which packages to update
+          if [[ -n "${{ inputs.packages }}" ]]; then
+            # Use multi-selection field with dev: prefix support
+            PACKAGES_INPUT="${{ inputs.packages }}"
+            
+            # Parse comma-separated packages
+            IFS=',' read -ra PACKAGES <<< "$PACKAGES_INPUT"
+            
+            # Get actual installed versions for all packages
+            VERSIONS=""
+            for PACKAGE_ENTRY in "${PACKAGES[@]}"; do
+              # Trim whitespace
+              PACKAGE_ENTRY=$(echo "$PACKAGE_ENTRY" | xargs)
+              
+              # Check for dev: prefix
+              if [[ "$PACKAGE_ENTRY" == dev:* ]]; then
+                PACKAGE="${PACKAGE_ENTRY#dev:}"
+                DEV_PREFIX="dev:"
+              else
+                PACKAGE="$PACKAGE_ENTRY"
+                DEV_PREFIX=""
+              fi
+              
+              VERSION=$(npm explore --no-workspaces "$PACKAGE" "node -pe 'require(\"./package.json\").version'" --shell sh)
+              if [[ -n "$VERSIONS" ]]; then
+                VERSIONS="$VERSIONS, "
+              fi
+              VERSIONS="$VERSIONS$DEV_PREFIX$PACKAGE@$VERSION"
+            done
+          elif [[ -n "${{ inputs.package }}" ]]; then
+            # Use single selection field
+            PACKAGE="${{ inputs.package }}"
+            VERSION=$(npm explore --no-workspaces "$PACKAGE" "node -pe 'require(\"./package.json\").version'" --shell sh)
+            
+            if [[ "${{ inputs.update_as_dev }}" == "true" ]]; then
+              VERSIONS="dev:$PACKAGE@$VERSION"
+            else
+              VERSIONS="$PACKAGE@$VERSION"
+            fi
+          else
+            echo "::error::Either package or packages must be specified"
+            exit 1
+          fi
 
           # Configure git
           git config --global user.email "95919151+yc-ui-bot@users.noreply.github.com"
           git config --global user.name "yc-ui-bot"
 
-          # Create branch and commit
-          BRANCH_NAME="ci/update-deps/${{ inputs.package }}-$VERSION"
+          # Create branch name (use first package for simplicity)
+          # Remove dev: prefix and @ symbol for valid branch name
+          FIRST_PACKAGE=$(echo "$PACKAGES_INPUT" | cut -d',' -f1 | xargs)
+          FIRST_PACKAGE=$(echo "$FIRST_PACKAGE" | sed 's/^dev://; s/@//g')
+          BRANCH_NAME="ci/update-deps/$FIRST_PACKAGE-${{ inputs.version }}"
           git push -f origin :$BRANCH_NAME || true
           git checkout -b $BRANCH_NAME
           git add package.json package-lock.json
-          git commit -m "fix(deps): Update ${{ inputs.package }} to $VERSION" --no-verify
+          git commit -m "fix(deps): Update $VERSIONS" --no-verify
           git push -u origin $BRANCH_NAME
 
           # Create PR
-          gh pr create --title "fix(deps): Update ${{ inputs.package }} to $VERSION" --body "Automated dependency update" --base master
+          gh pr create --title "fix(deps): Update $VERSIONS" --body "Automated dependency update" --base master

--- a/src/lib/common/id-generator.ts
+++ b/src/lib/common/id-generator.ts
@@ -5,6 +5,14 @@
 export type IDGenerator = (prefix?: string) => string;
 
 /**
+ * Strategy for generating element IDs (tabs, terms, code blocks, etc.).
+ * - `'random'` (default): uses `Math.random()` — legacy behavior, non-deterministic.
+ * - `'deterministic'`: uses per-file counters with prefix (e.g. `'term-1'`).
+ * - `'constant'`: always returns `'1'` — eliminates ID noise when diffing build outputs.
+ */
+export type IDGeneratorStrategy = 'random' | 'deterministic' | 'constant';
+
+/**
  * Creates an isolated ID generator with its own counter per prefix.
  * Call once per file/document to ensure IDs start from 1 for each file.
  *
@@ -28,4 +36,31 @@ export function createIDGenerator(): IDGenerator {
 
         return `${prefix}-${counters.get(prefix)}`;
     };
+}
+
+/**
+ * Factory that creates an {@link IDGenerator} based on the chosen strategy.
+ *
+ * @param strategy - The ID generation strategy to use.
+ * @returns An {@link IDGenerator} function for the selected strategy.
+ *
+ * @example
+ * // In CLI or any consumer:
+ * const generateID = createIDGeneratorByStrategy('deterministic');
+ * // Pass to transform options — plugins will use it instead of random IDs
+ *
+ * @example
+ * const generateID = createIDGeneratorByStrategy('random');
+ * // Returns a generator with legacy random behavior
+ */
+export function createIDGeneratorByStrategy(strategy: IDGeneratorStrategy = 'random'): IDGenerator {
+    switch (strategy) {
+        case 'deterministic':
+            return createIDGenerator();
+        case 'constant':
+            return () => '1';
+        case 'random':
+        default:
+            return () => Math.random().toString(36).substr(2, 8);
+    }
 }

--- a/src/lib/common/index.ts
+++ b/src/lib/common/index.ts
@@ -4,7 +4,7 @@ export type {
     ScriptStore,
 } from './extension-load-queue';
 
-export type {IDGenerator} from './id-generator';
+export type {IDGenerator, IDGeneratorStrategy} from './id-generator';
 
 export {AttrsParser} from './attrs';
 
@@ -14,4 +14,4 @@ export {createLoadQueue, getQueueStore, getScriptStore} from './extension-load-q
 
 export {isBrowser} from './browser';
 
-export {createIDGenerator} from './id-generator';
+export {createIDGenerator, createIDGeneratorByStrategy} from './id-generator';

--- a/test/id-generator.test.ts
+++ b/test/id-generator.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest';
 
-import {createIDGenerator} from '../src/lib/common';
+import {createIDGenerator, createIDGeneratorByStrategy} from '../src/lib/common';
 
 describe('createIDGenerator', () => {
     describe('with prefix', () => {
@@ -76,6 +76,87 @@ describe('createIDGenerator', () => {
             const generateID = createIDGenerator();
             expect(() => generateID()).not.toThrow();
             expect(() => generateID('prefix')).not.toThrow();
+        });
+    });
+});
+
+describe('createIDGeneratorByStrategy', () => {
+    describe("strategy 'random'", () => {
+        it('returns a function', () => {
+            const generateID = createIDGeneratorByStrategy('random');
+            expect(typeof generateID).toBe('function');
+        });
+
+        it('returns random strings when called without prefix', () => {
+            const generateID = createIDGeneratorByStrategy('random');
+            const ids = new Set(Array.from({length: 10}, () => generateID()));
+            expect(ids.size).toBe(10);
+        });
+
+        it('returns prefixed random strings when called with prefix', () => {
+            const generateID = createIDGeneratorByStrategy('random');
+            const id = generateID();
+
+            expect(id).toMatch(/[\w\d]{1,8}/);
+        });
+    });
+
+    describe("strategy 'deterministic'", () => {
+        it('returns a function', () => {
+            const generateID = createIDGeneratorByStrategy('deterministic');
+            expect(typeof generateID).toBe('function');
+        });
+
+        it('returns a counter-based generator (same as createIDGenerator)', () => {
+            const generateID = createIDGeneratorByStrategy('deterministic')!;
+            expect(generateID('tab')).toBe('tab-1');
+            expect(generateID('tab')).toBe('tab-2');
+            expect(generateID('section')).toBe('section-1');
+        });
+
+        it('creates a new isolated instance on each call', () => {
+            const gen1 = createIDGeneratorByStrategy('deterministic')!;
+            const gen2 = createIDGeneratorByStrategy('deterministic')!;
+
+            gen1('x');
+            gen1('x');
+
+            expect(gen1('x')).toBe('x-3');
+            expect(gen2('x')).toBe('x-1');
+        });
+    });
+
+    describe("strategy 'constant'", () => {
+        it('returns a function', () => {
+            const generateID = createIDGeneratorByStrategy('constant');
+            expect(typeof generateID).toBe('function');
+        });
+
+        it("always returns '1' regardless of prefix", () => {
+            const generateID = createIDGeneratorByStrategy('constant')!;
+            expect(generateID('tab')).toBe('1');
+            expect(generateID('tab')).toBe('1');
+            expect(generateID('section')).toBe('1');
+            expect(generateID()).toBe('1');
+        });
+    });
+
+    describe('default behavior', () => {
+        it("uses 'random' strategy when called without arguments", () => {
+            const generateID = createIDGeneratorByStrategy();
+            const ids = new Set(Array.from({length: 10}, () => generateID()));
+            expect(ids.size).toBe(10);
+        });
+    });
+
+    describe('unknown strategy', () => {
+        it('falls through to random generator for unrecognized strategy', () => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const generateID = createIDGeneratorByStrategy('unknown' as any);
+            const id = generateID();
+
+            expect(typeof generateID).toBe('function');
+            expect(id).toMatch(/[\w\d]{1,8}/);
         });
     });
 });


### PR DESCRIPTION
## What has been done

Moved and unified the ID generation logic in the build pipeline.

### Major changes
- Added CLI option [`--id-generator`](packages/cli/src/commands/build/config.ts) with strategies `random` / `deterministic` / `constant`
- in [`@diplodoc/utils`](packages/utils/src/lib/common/id-generator.ts), the following are exported:
  - the [`IDGeneratorStrategy`](packages/utils/src/lib/common/id-generator.ts:13) type
  - the [`createIDGeneratorByStrategy()`](packages/utils/src/lib/common/id-generator.ts:56) factory
- the `constant` strategy returns `'1'` and allows you to remove noise in the diff when comparing build results
- CLI, transform, and extensions have been converted to use [`createIDGeneratorByStrategy()`](packages/utils/src/lib/common/id-generator.ts:56)
- `WeakMap`-registry and singletons have been removed from [`tabs`](extensions/tabs/src/plugin/transform.ts) and [`folding-headings`](extensions/folding-headings/src/plugin/transform.ts)
- in [`folding-headings`](extensions/folding-headings/src/plugin/plugin.ts), singleton instances of rules/plugin have been removed to prevent ID counters from leaking between tests and documents
- the fallback for `random`/default is now set explicitly via [`createIDGeneratorByStrategy()`](packages/utils/src/lib/common/id-generator.ts:56), rather than via `undefined`
- fixed additional places where the strategy was lost:
- [`packages/transform/src/transform/plugins/utils.ts`](packages/transform/src/transform/plugins/utils.ts )
- [`packages/cli/src/commands/build/features/output-md/plugins/merge-svg.ts`](packages/cli/src/commands/build/features/output-md/plugins/merge-svg.ts)
- updated tests for the new `default` and `random` logic in [`packages/utils/test/id-generator.test.ts`](packages/utils/test/id-generator.test.ts)

## Why

Previously, the ID generation logic was spread out in several places, and part of the fallback behavior lived separately from the build configuration. Because of this:
- it was difficult to centrally manage the ID generation strategy
- deterministic/constant behavior was not applied in all pipeline branches
- in some places the hidden state was preserved
- the tests could depend on singleton generators

Now the strategy is set in one place and consistently applied throughout the pipeline.

## Result

- a single point of choice for ID generation strategy
- consistent behavior for `random`, `deterministic`, and `constant`
- no state leakage between documents and tests
- less noise in diff when using `constant`
- more predictable default behavior for random generation