### PR TITLE
fix: import ScriptScore to apply TS 6

### DIFF
--- a/src/lib/react/extension-load-queue.ts
+++ b/src/lib/react/extension-load-queue.ts
@@ -1,4 +1,4 @@
-import type {ScriptStore} from '../common';
+import type {ScriptStore} from '../common/extension-load-queue';
 
 import {useEffect, useState} from 'react';
 


### PR DESCRIPTION
Fixed the ScriptStore import to prevent build failures. 
After migrating the utilities to TypeScript 6, ScriptStore must also be imported in extension-load-queue, rather than only in the common module.